### PR TITLE
Change link parameter "type" to "role"

### DIFF
--- a/templates/index.hbs
+++ b/templates/index.hbs
@@ -54,7 +54,7 @@
                 <p class="card-text">
                     When and where do we meet? What do we do there?
                 </p>
-                <a type="button" class="btn btn-rcos" href="/meetings">
+                <a role="button" class="btn btn-rcos" href="/meetings">
                     Schedule
                 </a>
             </div>


### PR DESCRIPTION
This is a very quick fix to the Safari rendering issue that I found. One of the buttons on the index page used a "type" instead of a "role" for a button, which apparently is an issue on Safari; this PR should solve this issue.