### PR TITLE
Only allow Discord sign-ups

### DIFF
--- a/src/templates/auth.rs
+++ b/src/templates/auth.rs
@@ -69,7 +69,7 @@ pub fn login() -> Template {
         item(
             DiscordOAuth::login_path(),
             "btn-discord mb-2",
-            "Login using",
+            "Login using Discord",
             // This is manually coded for in the template file and is not
             // a Feather icon. Do not use it in other places, as it won't work.
             Some("discord"),

--- a/src/templates/auth.rs
+++ b/src/templates/auth.rs
@@ -85,12 +85,12 @@ pub fn login() -> Template {
 pub fn register() -> Template {
     // Make list of identity providers in account creation configuration.
     let items: Vec<Map<String, Value>> = vec![
-        item(
-            GitHubOauth::register_path(),
-            "btn-github mb-2",
-            "Register using GitHub",
-            Some("github"),
-        ),
+//         item(
+//             GitHubOauth::register_path(),
+//             "btn-github mb-2",
+//             "Register using GitHub",
+//             Some("github"),
+//         ),
         item(
             DiscordOAuth::register_path(),
             "btn-discord mb-2",
@@ -99,12 +99,12 @@ pub fn register() -> Template {
             // a Feather icon. Do not use it in other places, as it won't work.
             Some("discord"),
         ),
-        item(
-            RpiCas::register_path(),
-            "btn-rpi",
-            "Register using RPI CAS",
-            None,
-        ),
+//         item(
+//             RpiCas::register_path(),
+//             "btn-rpi",
+//             "Register using RPI CAS",
+//             None,
+//         ),
     ];
 
     // Create and return template.

--- a/templates/auth.hbs
+++ b/templates/auth.hbs
@@ -9,7 +9,7 @@
                     {{message}}
                     {{#if icon}}
                         {{#if (eq icon "discord")}}
-                            Discord <span class="fab">&#xf392;</span>
+                            <span class="fab">&#xf392;</span>
                         {{else}}
                             <i data-feather="{{icon}}"></i>
                         {{/if}}


### PR DESCRIPTION
67% of users have a Discord account linked but not CAS. If they accidentally sign up with CAS then a duplicate is created with no way of us realizing it unless the user tries to connect Discord. 

If we only allow Discord sign-up, users cannot accidentally create duplicate accounts and we can direct everyone to signup/login with Discord and then immediately connect with CAS, filling in the blanks. Once we have done that, we can reenable the other signup methods.