### PR TITLE
Add dynamic OGP tags

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -332,7 +332,7 @@ impl TelescopeError {
                 // Render the form.
                 let page_content: String = form.render()?;
                 // Put it in a page.
-                return page::with_content(req, form.page_title, page_content.as_str())
+                return page::with_content(req, form.page_title, page_content.as_str(), None)
                     .await?
                     // Render Page
                     .render()

--- a/src/templates/forms.rs
+++ b/src/templates/forms.rs
@@ -63,7 +63,7 @@ impl Responder for FormTemplate {
             let rendered: String = self.render()?;
 
             // Put it in a page.
-            page::with_content(&req, self.page_title, rendered.as_str())
+            page::with_content(&req, self.page_title, rendered.as_str(), None)
                 // Wait for the page to resolve the user ID etc
                 .await?
                 // Render the page to HTML

--- a/src/templates/mod.rs
+++ b/src/templates/mod.rs
@@ -16,6 +16,7 @@ pub mod navbar;
 pub mod page;
 pub mod pagination;
 pub mod static_pages;
+pub mod tags;
 
 /// A template that can be rendered using the handlebars template registry.
 #[derive(Serialize, Debug, Clone)]
@@ -70,7 +71,16 @@ impl Template {
         req: &HttpRequest,
         title: impl Into<Value>,
     ) -> Result<Template, TelescopeError> {
-        page::of(req, title, self).await
+        Self::render_into_page_with_tags(self, req, title, None).await
+    }
+
+    pub async fn render_into_page_with_tags(
+        &self,
+        req: &HttpRequest,
+        title: impl Into<Value>,
+        tags: Option<tags::Tags>
+    ) -> Result<Template, TelescopeError> {
+        page::of_with_tags(req, title, self, tags).await
     }
 }
 

--- a/src/templates/page.rs
+++ b/src/templates/page.rs
@@ -1,6 +1,7 @@
 use crate::error::TelescopeError;
 use crate::templates::navbar;
 use crate::templates::Template;
+use crate::templates::tags;
 use actix_web::HttpRequest;
 use serde_json::Value;
 
@@ -20,17 +21,30 @@ pub const CONTENT: &'static str = "content";
 /// is currently running.
 pub const VERSION: &'static str = "version";
 
-/// Create a new template object to hold the page.
-/// The content of the page is rendered here and must be re-rendered if updated.
+/// The handlebars field to fill OG tags
+pub const TAGS: &'static str = "tags";
+
+/// Calls of_with_tags with a None option for tags so default tags are used
 pub async fn of(
     req: &HttpRequest,
     title: impl Into<Value>,
+    content: &Template
+) -> Result<Template, TelescopeError> {
+    of_with_tags(req, title, content, None)
+}
+
+/// Create a new template object to hold the page.
+/// The content of the page is rendered here and must be re-rendered if updated.
+pub async fn of_with_tags(
+    req: &HttpRequest,
+    title: impl Into<Value>,
     content: &Template,
+    tags: Option<tags::Tags>
 ) -> Result<Template, TelescopeError> {
     // Render the content of this page
     let content_rendered: String = content.render()?;
     // Create the page.
-    return with_content(req, title, content_rendered.as_str()).await;
+    return with_content(req, title, content_rendered.as_str(), tags).await;
 }
 
 /// Create a template with a content string rather than another template.
@@ -38,11 +52,13 @@ pub async fn with_content(
     req: &HttpRequest,
     title: impl Into<Value>,
     content: &str,
+    tags: Option<tags::Tags>
 ) -> Result<Template, TelescopeError> {
     // Build the rest of the page
     Ok(Template::new(TEMPLATE_PATH)
         .field(TITLE, title.into())
         .field(NAVBAR, navbar::for_request(req).await?)
         .field(CONTENT, content)
-        .field(VERSION, env!("CARGO_PKG_VERSION")))
+        .field(VERSION, env!("CARGO_PKG_VERSION"))
+        .field(TAGS, tags.unwrap_or(tags::Tags::default())))
 }

--- a/src/templates/page.rs
+++ b/src/templates/page.rs
@@ -30,7 +30,7 @@ pub async fn of(
     title: impl Into<Value>,
     content: &Template
 ) -> Result<Template, TelescopeError> {
-    of_with_tags(req, title, content, None)
+    of_with_tags(req, title, content, None).await
 }
 
 /// Create a new template object to hold the page.

--- a/src/templates/tags.rs
+++ b/src/templates/tags.rs
@@ -1,0 +1,25 @@
+use crate::env::global_config;
+
+#[derive(Serialize, Clone)]
+pub struct Tags {
+    pub title: String,
+    #[serde(rename = "type")]
+    pub og_type: String,
+    pub url: String,
+    pub description: String,
+    pub image: String,
+    pub site_name: String
+}
+
+impl Tags {
+    pub fn default() -> Self {
+        Tags {
+            title: "Rensselaer Center for Open Source".to_string(),
+            og_type: "website".to_string(),
+            url: global_config().discord_config.telescope_url.clone(),
+            description: "The Rensselaer Center for Open Source - or RCOS (ar-kos) for short - is a community of motivated students at Rensselaer Polytechnic Institute who develop open source projects under the guidance of experienced instructors and student mentors.".to_string(),
+            image: format!("{}/{}", global_config().discord_config.telescope_url, "static/icons/rcos-branding/img/logo-square-red.png"),
+            site_name: "Telescope".to_string()
+        }
+    }
+}

--- a/src/web/services/meetings/view.rs
+++ b/src/web/services/meetings/view.rs
@@ -7,6 +7,9 @@ use crate::templates::Template;
 use crate::web::services::auth::identity::Identity;
 use actix_web::web::Path;
 use actix_web::HttpRequest;
+use chrono::{Local, TimeZone};
+use crate::env::global_config;
+use crate::templates::tags::Tags;
 
 /// The path from the templates directory to this template.
 const TEMPLATE_PATH: &'static str = "meetings/page";
@@ -60,12 +63,46 @@ pub async fn meeting(
         });
     }
 
+    // Create dynamic OGP tags and start with default so all other fields are correct
+    let mut tags = Tags::default();
+    tags.title = if meeting.title.is_some() { format!("RCOS {} - {}", meeting.type_, meeting.title()) } else { meeting.title() };
+    tags.url = format!("{}/meeting/{}", global_config().discord_config.telescope_url, meeting_id);
+
+    let mut description = String::new();
+    let start = Local.from_utc_datetime(&meeting.start_date_time.naive_utc());
+    let end = Local.from_utc_datetime(&meeting.end_date_time.naive_utc());
+    if start.date() == end.date() {
+        description.push_str(format!("{}{} -{}", start.format("%B %_d, %Y"), start.format("%_I:%M %P"), end.format("%_I:%M %P")).as_str());
+    }
+    else {
+        description.push_str(format!("{} at{} - {} at{}", start.format("%B %_d, %Y"), start.format("%_I:%M %P"),
+                                     end.format("%B %_d, %Y"), end.format("%_I:%M %P")).as_str());
+    }
+    if meeting.location.is_some() {
+        let location = meeting.location.as_ref().unwrap();
+        if location != "" {
+            description.push_str(format!(" @ {}", location).as_str());
+        }
+    }
+    else if meeting.is_remote {
+        description.push_str(" @ Remote");
+    }
+    description.push_str("\n");
+    if meeting.host.is_some() {
+        let host = meeting.host.as_ref().unwrap();
+        description.push_str(format!("Hosted By: {} {}\n", host.first_name, host.last_name).as_str());
+    }
+    if meeting.description != "" {
+        description.push_str(meeting.description.as_str());
+    }
+    tags.description = description;
+
     // If the meeting is visible to the viewer, make and return the template.
     return Template::new(TEMPLATE_PATH)
         .field("meeting", &meeting)
         .field("auth", authorization)
         // Rendered inside a page
-        .render_into_page(&req, meeting.title())
+        .render_into_page_with_tags(&req, meeting.title(), Some(tags))
         // Wait for page to render and return result.
         .await;
 }

--- a/templates/og_tags.hbs
+++ b/templates/og_tags.hbs
@@ -1,0 +1,4 @@
+{{#each this}}
+        {{! Two tabs so HTML formats properly according to page.hbs }}
+        <meta property="og:{{ @key }}" content="{{ this }}" />
+{{/each}}

--- a/templates/page.hbs
+++ b/templates/page.hbs
@@ -3,11 +3,9 @@
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <meta property="og:title" content="Rensselaer Center for Open Source" />
-        <meta property="og:type" content="website" />
-        <meta property="og:url" content="https://rcos.io/" />
-        <meta property="og:description" content="The Rensselaer Center for Open Source - or RCOS (ar-kos) for short - is a community of motivated students at Rensselaer Polytechnic Institute who develop open source projects under the guidance of experienced instructors and student mentors." />
-        <meta property="og:image" content="https://rcos.io/static/icons/rcos-branding/img/logo-square-red.png" />
+
+            {{> og_tags tags}}
+
         <title>
             {{title}}
         </title>


### PR DESCRIPTION
This PR adds support for dynamic OGP tags and implements them for meetings. Other pages could do something similar to get custom static OGP or dynamic OGP tags. For testing locally, I would recommend using ngrok so Discord can read the page and display the embed.

Here is an example of what a dynamic OGP tags on Discord would look like (a description and host would also show if either were provided):
![image](https://user-images.githubusercontent.com/55092742/147726062-b562eff1-51e7-4abb-adc7-c505ab755906.png)
