### PR TITLE
Fix host selection in meeting editing

### DIFF
--- a/graphql/rcos/meetings/edit/host_selection.graphql
+++ b/graphql/rcos/meetings/edit/host_selection.graphql
@@ -46,7 +46,7 @@ query EditHostSelection($meeting_id: Int!) {
             }
 
             # Everyone else alphabetically
-            enrollments(order_by: [{user: {first_name: asc}}, {userByUserId: {last_name: asc}}]) {
+            enrollments(order_by: [{user: {first_name: asc}}, {user: {last_name: asc}}]) {
                 user { ... HostInfo }
             }
         }

--- a/src/web/services/meetings/edit.rs
+++ b/src/web/services/meetings/edit.rs
@@ -93,17 +93,19 @@ fn resolve_host_user_id(
     meeting_data: &MeetingMeeting,
     set_host: Option<Query<HostQuery>>,
 ) -> Option<Uuid> {
-    // The current host ID from the meeting data.
-    let existing_host: Option<Uuid> = meeting_data.host.as_ref().map(|h| h.id);
+    match set_host {
+        // If there is a specified nil UUID we want no host. Otherwise, we want the specified UUID.
+        Some(Query(HostQuery{ set_host })) => {
+            if set_host.is_nil() {
+                None
+            } else {
+                Some(set_host)
+            }
+        },
 
-    // The new host's user ID if not set to nil.
-    let new_host: Option<Uuid> = set_host.and_then(|q| {
-        let set_host = q.set_host;
-        // Check for nil UUID here.
-        (!set_host.is_nil()).then(|| set_host)
-    });
-
-    return new_host.or(existing_host);
+        // If there is no host query then use the existing host parameter (which may be none).
+        None => meeting_data.host.as_ref().map(|h| h.id),
+    }
 }
 
 /// Resolve the meeting title value. This is the supplied title or a combination of the meeting

--- a/templates/meetings/edit/host_selection.hbs
+++ b/templates/meetings/edit/host_selection.hbs
@@ -10,7 +10,9 @@
                 </div>
 
                 <div class="col-12 col-md-8">
-                    <a href="/meeting/{{meeting_id}}/edit?{{url_encode set_host=""}}" class="btn btn-primary w-100">
+                    {{! Use nil UUID to indicate no host }}
+                    <a href="/meeting/{{meeting_id}}/edit?{{url_encode set_host="00000000-0000-0000-0000-000000000000"}}"
+                       class="btn btn-primary w-100">
                         Select no host.
                     </a>
                 </div>
@@ -54,7 +56,7 @@
                                     </td>
 
                                     <td>
-                                        <a href="/meeting/{{../../meeting_id}}/edit?{{url_encode set_host=username}}" class="btn btn-primary">
+                                        <a href="/meeting/{{../../meeting_id}}/edit?{{url_encode set_host=id}}" class="btn btn-primary">
                                             Select...
                                         </a>
                                     </td>
@@ -110,7 +112,7 @@
                                         </td>
 
                                         <td>
-                                            <a href="/meeting/{{../../../meeting_id}}/edit?{{url_encode set_host=username}}" class="btn btn-primary">
+                                            <a href="/meeting/{{../../../meeting_id}}/edit?{{url_encode set_host=id}}" class="btn btn-primary">
                                                 Select...
                                             </a>
                                         </td>
@@ -161,7 +163,7 @@
                                     </td>
 
                                     <td>
-                                        <a href="/meeting/{{../../meeting_id}}/edit?{{url_encode set_host=username}}" class="btn btn-primary">
+                                        <a href="/meeting/{{../../meeting_id}}/edit?{{url_encode set_host=id}}" class="btn btn-primary">
                                             Select...
                                         </a>
                                     </td>


### PR DESCRIPTION
There was previously a HTTP 500 - RCOS Hasura API error when attempting to select a host for an existing meeting. This PR fixes that and also Fixes a bug that prevented the selected host from being saved. 