### PR TITLE
Add OGP tags for user profiles

### DIFF
--- a/src/web/services/user/profile.rs
+++ b/src/web/services/user/profile.rs
@@ -88,7 +88,7 @@ async fn profile(
                 // Return early if there was an error.
                 // Otherwise we can go forward and check for the user's membership in the RCOS
                 // Discord server.
-                return template.in_page(&req, page_title.clone()).await;
+                return template.in_page(&req, page_title).await;
             }
 
             // User returned successfully.
@@ -148,10 +148,8 @@ async fn profile(
 
     let mut tags = Tags::default();
     tags.title = page_title.clone();
-    tags.url = format!("/user/{}", id);
-    let mut description = String::new();
-    description.push_str(target_user.role.to_string().as_str());
-    description.push_str("\n");
+    tags.url = req.uri().to_string();
+    let mut description = format!("{}\n", target_user.role);
     if target_user.rcs_id.len() > 0 {
         description.push_str("Email: ");
         description.push_str(&target_user.rcs_id[0].account_id);

--- a/src/web/services/user/profile.rs
+++ b/src/web/services/user/profile.rs
@@ -19,6 +19,7 @@ use serenity::model::guild::Member;
 use serenity::model::user::User;
 use std::collections::HashMap;
 use uuid::Uuid;
+use crate::templates::tags::Tags;
 
 /// The path from the template directory to the profile template.
 const TEMPLATE_NAME: &'static str = "user/profile";
@@ -87,7 +88,7 @@ async fn profile(
                 // Return early if there was an error.
                 // Otherwise we can go forward and check for the user's membership in the RCOS
                 // Discord server.
-                return template.in_page(&req, page_title).await;
+                return template.in_page(&req, page_title.clone()).await;
             }
 
             // User returned successfully.
@@ -143,7 +144,44 @@ async fn profile(
     }
 
     // Render the profile template and send to user.
-    return template.in_page(&req, page_title).await;
+    let mut page = template.in_page(&req, page_title.clone()).await?;
+
+    let mut tags = Tags::default();
+    tags.title = page_title.clone();
+    tags.url = format!("/user/{}", id);
+    let mut description = String::new();
+    description.push_str(target_user.role.to_string().as_str());
+    description.push_str("\n");
+    if target_user.rcs_id.len() > 0 {
+        description.push_str("Email: ");
+        description.push_str(&target_user.rcs_id[0].account_id);
+        description.push_str("@rpi.edu\n");
+    }
+    if target_user.enrollments.len() > 0 {
+        description.push_str("Enrollments:\n");
+        for enrollment in &target_user.enrollments {
+            let semester = &enrollment.semester;
+            description.push_str(&semester.title);
+            let project = enrollment.project.as_ref();
+            if project.is_some() {
+                let project = project.unwrap();
+                description.push_str(" - ");
+                if enrollment.is_coordinator {
+                    description.push_str("Coordinator - ");
+                }
+                description.push_str(&project.title);
+                if enrollment.is_project_lead {
+                    description.push_str(" - Project Lead");
+                }
+            }
+            description.push_str("\n");
+        }
+    }
+    tags.description = description;
+
+    page.ogp_tags = tags;
+
+    return Ok(page)
 }
 
 /// Create a form template for the user settings page.


### PR DESCRIPTION
This adds OGP tags for profile pages. Here is an example of what it might look like on discord.

![image](https://user-images.githubusercontent.com/55092742/148631291-0531501a-fb02-4d0f-b95a-579d59363567.png)

Coordinator and Project Lead are conditionally shown if that user happens to be those for that semester.