### PR TITLE
Update to hasura that supports ARM, remove restart

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,6 @@ version: "3.1"
 services:
   db:
     image: postgres:latest
-    restart: always
     environment:
       POSTGRES_PASSWORD: "${POSTGRES_PASSWORD}"
     volumes:
@@ -16,7 +15,7 @@ services:
 
   # Hasura Postgres -> GraphQL engine
   hasura:
-    image: hasura/graphql-engine:v2.0.10
+    image: hasura/graphql-engine:v2.2.0
     restart: unless-stopped
     depends_on:
       - db


### PR DESCRIPTION
We have a new contributor that uses a macbook with the arm64 architecture. Thankfully, hasura supports this, but only in the latest release.

I also disabled auto restart for postgres, because it should only really be crashing if theres a severe problem.

I've tested the new hasura using qemu.