### PR TITLE
improved copy-ability

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ update Telescope's git `rcos-data` submodule to point to the newest commit on th
 `telescope-dev-version` branch. After you have done this and pulled the submodule,
 update the local database using the hasura client. The commands should look like this:
 ```shell
-$ hasura --project rcos-data/ migrate --admin-secret xxxxxxxxxxxxxxxxxxxxxxxx --endpoint http://localhost:8000 apply
-$ hasura --project rcos-data/ metadata --admin-secret xxxxxxxxxxxxxxxxxxxxxxxx --endpoint http://localhost:8000 reload
+hasura --project rcos-data/ migrate --admin-secret xxxxxxxxxxxxxxxxxxxxxxxx --endpoint http://localhost:8000 apply
+hasura --project rcos-data/ metadata --admin-secret xxxxxxxxxxxxxxxxxxxxxxxx --endpoint http://localhost:8000 reload
 ``` 
 where `xxxxxxxxxxxxxxxxxxxxxxxx` is replaced by the hasura admin secret in your `.env` file.
 After applying the migrations, go to the hasura console to make sure that all the proper
@@ -61,11 +61,11 @@ There are several of these that are probably acceptable, but for consistency we 
 the [`graphql-rust client`](https://github.com/graphql-rust/graphql-client/tree/master/graphql_client_cli). 
 Install this using the command from its README.
 ```shell
-$ cargo install graphql_client_cli --force
+cargo install graphql_client_cli --force
 ```
 Finally, regenerate Telescope's `schema.json` file as follows:
 ```shell
-$ graphql-client introspect-schema --header 'x-hasura-admin-secret: xxxxxxxxxxxxxxxxxxxxxxxx' --output graphql/rcos/schema.json http://localhost:8000/v1/graphql
+graphql-client introspect-schema --header 'x-hasura-admin-secret: xxxxxxxxxxxxxxxxxxxxxxxx' --output graphql/rcos/schema.json http://localhost:8000/v1/graphql
 ```
 again, `xxxxxxxxxxxxxxxxxxxxxxxx` is replaced by the hasura admin secret in your `.env` file.
 
@@ -74,7 +74,7 @@ copy of that in telescope. This requires a GitHub Personal Access Token (PAT)
 which you can generate [here](https://github.com/settings/tokens). Once you have
 generated your PAT, you can introspect/update the local GitHub Schema using
 ```shell 
-$ graphql-client introspect-schema --output graphql/github/schema.json --authorization "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" https://api.github.com/graphql
+graphql-client introspect-schema --output graphql/github/schema.json --authorization "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" https://api.github.com/graphql
 ```
 where `xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx` is replaced by your PAT.
 
@@ -82,14 +82,14 @@ where `xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx` is replaced by your PAT.
 1. Install dependencies:
     1. Rust (see [https://www.rust-lang.org/](https://www.rust-lang.org/) for more info)
         ```shell
-        $ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-        $ source ~/.cargo/env
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+        source ~/.cargo/env
         ```
     2. Hasura CLI to run database migrations. See 
        [the hasura CLI docs](https://hasura.io/docs/1.0/graphql/core/hasura-cli/install-hasura-cli.html#install-hasura-cli) 
        for more info.
         ```shell
-        $ curl -L https://github.com/hasura/graphql-engine/raw/stable/cli/get.sh | bash
+        curl -L https://github.com/hasura/graphql-engine/raw/stable/cli/get.sh | bash
         ```
     3. Docker and docker-compose to run telescope and the database locally. 
        this can be a complicated process, but there are good instructions online 
@@ -98,7 +98,7 @@ where `xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx` is replaced by your PAT.
        
 2. Clone this repository:
     ```shell script
-    $ git clone --recurse-submodules https://github.com/rcos/Telescope.git
+    git clone --recurse-submodules https://github.com/rcos/Telescope.git
     ```
    You need to make sure you get all of the submodules here using 
    `--recurse-submodules` otherwise you won't have any of the RCOS branding
@@ -117,30 +117,30 @@ where `xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx` is replaced by your PAT.
    
 5. Build and start the docker images.
     ```shell
-    $ docker-compose up -d 
+    docker-compose up -d 
     ```
 
 6. Run the database migrations. Replace the "xx.." in the command with the admin 
    secret from your `.env` file. Make sure the `admin-secret` is at least 32 characters long.
     ```shell
-    $ hasura --project rcos-data/ migrate --admin-secret xxxxxxxxxxxxxxxxxxxxxxxx --endpoint http://localhost:8000 apply
+    hasura --project rcos-data/ migrate --admin-secret xxxxxxxxxxxxxxxxxxxxxxxx --endpoint http://localhost:8000 apply
     ``` 
 7. Track the Hasura tables:
     In Hasura (http://localhost:8000), enter your `admin-secret` when prompted. Navigate to the "Data" tab, and click "Create Table". Track all tables, and hit "Add Table". You also want to press "Track All" for the foreign key relationships as well.
 8. Reload metadata:
    ```shell
-   $ hasura --project rcos-data/ metadata --admin-secret xxxxxxxxxxxxxxxxxxxxxxxx --endpoint http://localhost:8000 reload
+   hasura --project rcos-data/ metadata --admin-secret xxxxxxxxxxxxxxxxxxxxxxxx --endpoint http://localhost:8000 reload
    ```
 9. At this point Postgres, the Hasura GraphQL API, Caddy, and Telescope should 
    all be running on your system in individual docker containers. Docker 
    exposes the Hasura console at http://localhost:8000 and https://localhost:8001, 
    and Telescope is exposed at https://localhost:8443. To shut them all down, run
    ```shell
-   $ docker-compose down
+   docker-compose down
    ```
    If you only want to make changes to telescope, you don't need to take down
    all the containers. Simply make your changes, run `cargo check` to verify 
    that it compiles, and then rebuild just telescope in docker using
    ```shell
-   $ docker-compose up --build -d
+   docker-compose up --build -d
    ```


### PR DESCRIPTION
Removed `$` characters so bash commands can be copied from readme.  Noticed I couldn't copy and paste like I wanted to when cloning and building earlier.