### PR TITLE
Enable running outside of Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ graphql/rcos/.graphqlconfig
 graphql/rcos/schema.graphql
 graphql/github/schema.graphql
 graphql/github/.graphqlconfig
+
+# All future changes to the Caddyfile should be ignored due to it needing changes on macOS docker
+Caddyfile.dev

--- a/Caddyfile.dev
+++ b/Caddyfile.dev
@@ -1,0 +1,9 @@
+localhost:8001 {
+    encode zstd gzip
+    reverse_proxy hasura:8080
+}
+
+localhost:443 {
+    encode zstd gzip
+    reverse_proxy 172.18.0.1:8080
+}

--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ See below for detailed information on building & contributing to telescope.
     to register a new GitHub OAuth application or get a new client secret.
     You will also have to create a discord OAuth app and bot token. Instructions
     can be found in `config_example.toml`.  
+    
+    You must make sure that some of the items in the `.env` file match.
+    For example, the database password in `POSTGRES_PASSWORD` needs to be the
+    same as the one in `DATABASE_URL`. If you forget to do this, you will need
+    to reset the database (`docker-compose down --volumes`).
    
 5. Build and start the docker images.
     ```shell
@@ -53,7 +58,7 @@ See below for detailed information on building & contributing to telescope.
     ```
 
 6. Run the database migrations. Replace the "xx.." in the command with the admin 
-   secret from your `.env` file. Make sure the `admin-secret` is at least 32 characters long.
+   secret from your `.env` file. **Make sure the `admin-secret` is at least 32 characters long.**
     ```shell
     hasura --project rcos-data/ migrate --admin-secret xxxxxxxxxxxxxxxxxxxxxxxx --endpoint http://localhost:8000 apply
     ``` 
@@ -76,6 +81,33 @@ See below for detailed information on building & contributing to telescope.
    ```shell
    docker-compose up --build -d
    ```
+
+### Running Telescope outside of Docker
+
+Developing telescope with Docker is useful because you are testing Telescope in
+an almost identical environment to that which it runs on in production. In order
+to improve compile speed, due to the incremental compilation cache of Rust, you
+may want to develop and run Telescope outside of Docker. You can do this by
+following these *optional* instructions:
+
+1. Telescope typically uses the standard web port 80, but outside of Docker you
+   will need to change that to 8080 by setting `address` to `0.0.0.0:8080` in
+   `config.toml`. This is because port 80 is restricted.
+   
+2. On macOS, Docker runs within a virtual machine. That means that you need to
+   change `Caddyfile.dev` to point to your computer outside the virtual machine.
+   You only need to do this if you are using Docker Desktop on macOS.
+
+    ```
+    localhost:443 {
+        encode zstd gzip
+        reverse_proxy host.docker.internal:8080
+    }
+    ```
+
+3. The commands you use to run and test Telescope need to be changed. To start
+   the supporting services like Hasura, Postgres, and Caddy, run `docker-compose
+   -f docker-compose.dev.yml up -d`. To start Telescope, run `cargo run`.
 
 ## Development Notes
 These are note for Telescope Developers on how to find and update Telescope 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,73 @@ If you find issues with Telescope or have a feature you want added, please make 
 You should also feel free to contribute your own. Pull requests are welcome. 
 See below for detailed information on building & contributing to telescope.
 
+## Installation:
+1. Install dependencies:
+    1. Rust (see [https://www.rust-lang.org/](https://www.rust-lang.org/) for more info)
+        ```shell
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+        source ~/.cargo/env
+        ```
+    2. Hasura CLI to run database migrations. See 
+       [the hasura CLI docs](https://hasura.io/docs/1.0/graphql/core/hasura-cli/install-hasura-cli.html#install-hasura-cli) 
+       for more info.
+        ```shell
+        curl -L https://github.com/hasura/graphql-engine/raw/stable/cli/get.sh | bash
+        ```
+    3. Docker and docker-compose to run telescope and the database locally. 
+       this can be a complicated process, but there are good instructions online 
+       [here](https://docs.docker.com/get-docker/).
+       Message me for help if you need it.
+       
+2. Clone this repository:
+    ```shell script
+    git clone --recurse-submodules https://github.com/rcos/Telescope.git
+    ```
+   You need to make sure you get all of the submodules here using 
+   `--recurse-submodules` otherwise you won't have any of the RCOS branding
+   logos or icons, or any of the database migrations and setup.
+
+4. Copy the configuration templates as follows:
+    - `config_example.toml` -> `config.toml`
+    - `.env.example` -> `.env`
+    (note: the `config.toml` and `.env` files must be created yourself.) 
+    
+    Then modify them to match your environment. You may need to generate the 
+    GitHub related credentials. Go [here](https://github.com/settings/applications/new)
+    to register a new GitHub OAuth application or get a new client secret.
+    You will also have to create a discord OAuth app and bot token. Instructions
+    can be found in `config_example.toml`.  
+   
+5. Build and start the docker images.
+    ```shell
+    docker-compose up -d 
+    ```
+
+6. Run the database migrations. Replace the "xx.." in the command with the admin 
+   secret from your `.env` file. Make sure the `admin-secret` is at least 32 characters long.
+    ```shell
+    hasura --project rcos-data/ migrate --admin-secret xxxxxxxxxxxxxxxxxxxxxxxx --endpoint http://localhost:8000 apply
+    ``` 
+7. Track the Hasura tables:
+    In Hasura (http://localhost:8000), enter your `admin-secret` when prompted. Navigate to the "Data" tab, and click "Create Table". Track all tables, and hit "Add Table". You also want to press "Track All" for the foreign key relationships as well.
+8. Reload metadata:
+   ```shell
+   hasura --project rcos-data/ metadata --admin-secret xxxxxxxxxxxxxxxxxxxxxxxx --endpoint http://localhost:8000 reload
+   ```
+9. At this point Postgres, the Hasura GraphQL API, Caddy, and Telescope should 
+   all be running on your system in individual docker containers. Docker 
+   exposes the Hasura console at http://localhost:8000 and https://localhost:8001, 
+   and Telescope is exposed at https://localhost:8443. To shut them all down, run
+   ```shell
+   docker-compose down
+   ```
+   If you only want to make changes to telescope, you don't need to take down
+   all the containers. Simply make your changes, run `cargo check` to verify 
+   that it compiles, and then rebuild just telescope in docker using
+   ```shell
+   docker-compose up --build -d
+   ```
+
 ## Development Notes
 These are note for Telescope Developers on how to find and update Telescope 
 itself.
@@ -77,70 +144,3 @@ generated your PAT, you can introspect/update the local GitHub Schema using
 graphql-client introspect-schema --output graphql/github/schema.json --authorization "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" https://api.github.com/graphql
 ```
 where `xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx` is replaced by your PAT.
-
-## Installation:
-1. Install dependencies:
-    1. Rust (see [https://www.rust-lang.org/](https://www.rust-lang.org/) for more info)
-        ```shell
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-        source ~/.cargo/env
-        ```
-    2. Hasura CLI to run database migrations. See 
-       [the hasura CLI docs](https://hasura.io/docs/1.0/graphql/core/hasura-cli/install-hasura-cli.html#install-hasura-cli) 
-       for more info.
-        ```shell
-        curl -L https://github.com/hasura/graphql-engine/raw/stable/cli/get.sh | bash
-        ```
-    3. Docker and docker-compose to run telescope and the database locally. 
-       this can be a complicated process, but there are good instructions online 
-       [here](https://docs.docker.com/get-docker/).
-       Message me for help if you need it.
-       
-2. Clone this repository:
-    ```shell script
-    git clone --recurse-submodules https://github.com/rcos/Telescope.git
-    ```
-   You need to make sure you get all of the submodules here using 
-   `--recurse-submodules` otherwise you won't have any of the RCOS branding
-   logos or icons, or any of the database migrations and setup.
-
-4. Copy the configuration templates as follows:
-    - `config_example.toml` -> `config.toml`
-    - `.env.example` -> `.env`
-    (note: the `config.toml` and `.env` files must be created yourself.) 
-    
-    Then modify them to match your environment. You may need to generate the 
-    GitHub related credentials. Go [here](https://github.com/settings/applications/new)
-    to register a new GitHub OAuth application or get a new client secret.
-    You will also have to create a discord OAuth app and bot token. Instructions
-    can be found in `config_example.toml`.  
-   
-5. Build and start the docker images.
-    ```shell
-    docker-compose up -d 
-    ```
-
-6. Run the database migrations. Replace the "xx.." in the command with the admin 
-   secret from your `.env` file. Make sure the `admin-secret` is at least 32 characters long.
-    ```shell
-    hasura --project rcos-data/ migrate --admin-secret xxxxxxxxxxxxxxxxxxxxxxxx --endpoint http://localhost:8000 apply
-    ``` 
-7. Track the Hasura tables:
-    In Hasura (http://localhost:8000), enter your `admin-secret` when prompted. Navigate to the "Data" tab, and click "Create Table". Track all tables, and hit "Add Table". You also want to press "Track All" for the foreign key relationships as well.
-8. Reload metadata:
-   ```shell
-   hasura --project rcos-data/ metadata --admin-secret xxxxxxxxxxxxxxxxxxxxxxxx --endpoint http://localhost:8000 reload
-   ```
-9. At this point Postgres, the Hasura GraphQL API, Caddy, and Telescope should 
-   all be running on your system in individual docker containers. Docker 
-   exposes the Hasura console at http://localhost:8000 and https://localhost:8001, 
-   and Telescope is exposed at https://localhost:8443. To shut them all down, run
-   ```shell
-   docker-compose down
-   ```
-   If you only want to make changes to telescope, you don't need to take down
-   all the containers. Simply make your changes, run `cargo check` to verify 
-   that it compiles, and then rebuild just telescope in docker using
-   ```shell
-   docker-compose up --build -d
-   ```

--- a/config_example.toml
+++ b/config_example.toml
@@ -38,6 +38,13 @@ jwt_secret = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 # a slash.
 telescope_url = "https://rcos.io"
 
+
+# [REQUIRED]
+# The address for Telescope's server to bind at. You should leave this at
+# default if you are running Telescope with the default setup in
+# docker compose behind caddy
+address = "127.0.0.1:80"
+
 # [REQUIRED]
 # The GitHub OAuth application credentials.
 # These can be generated at https://github.com/settings/applications/new.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,53 @@
+# Development docker-compose file. Will pull up local Postgres database
+# and local PostgREST API for running telescope locally.
+version: "3.1"
+
+services:
+  db:
+    image: postgres:latest
+    environment:
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD}"
+    volumes:
+      - "/var/run/postgres/postgres.sock:/var/run/postgres/postgres.sock"
+      - "db_data:/var/lib/postgresql/data"
+    ports:
+      - "5432:5432"
+
+  # Hasura Postgres -> GraphQL engine
+  hasura:
+    image: hasura/graphql-engine:v2.2.0
+    depends_on:
+      - db
+    environment:
+      # https://hasura.io/docs/1.0/graphql/core/deployment/graphql-engine-flags/reference.html
+      HASURA_GRAPHQL_UNAUTHORIZED_ROLE: "web_anon"
+      HASURA_GRAPHQL_DATABASE_URL: "${DATABASE_URL}"
+      HASURA_GRAPHQL_DEV_MODE: "true"
+      HASURA_GRAPHQL_ENABLE_CONSOLE: "true"
+      HASURA_GRAPHQL_JWT_SECRET: "{ \"type\": \"HS256\", \"key\": \"${RCOS_JWT_SECRET}\" }"
+      HASURA_GRAPHQL_LOG_LEVEL: "info"
+      HASURA_GRAPHQL_ADMIN_SECRET: "${HASURA_GRAPHQL_ADMIN_SECRET}"
+    ports:
+      - "8000:8080"
+
+  # Use caddy for reverse proxy and TLS/SSL certs.
+  caddy:
+    image: caddy:2
+    volumes:
+      - "caddy_data:/data"
+      - "${PWD}/Caddyfile.dev:/etc/caddy/Caddyfile"
+    ports:
+      - "8001:8001"
+      - "8443:443"
+
+
+volumes:
+  db_data:
+  caddy_data:
+
+networks:
+  default:
+    ipam:
+      config:
+        - subnet: 172.18.0.0/16
+          gateway: 172.18.0.1

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -16,6 +16,7 @@ services:
   # Hasura Postgres -> GraphQL engine
   hasura:
     image: hasura/graphql-engine:v2.2.0
+    restart: unless-stopped
     depends_on:
       - db
     environment:
@@ -45,6 +46,7 @@ volumes:
   db_data:
   caddy_data:
 
+# We need to ensure a stable gateway ip if we want the caddyfile to point to the host each time
 networks:
   default:
     ipam:

--- a/graphql/rcos/projects/get_by_id.graphql
+++ b/graphql/rcos/projects/get_by_id.graphql
@@ -1,0 +1,13 @@
+query Project($id: Int!) {
+  project: projects_by_pk(project_id: $id) {
+    project_id
+    description
+    stack
+    repository_urls
+    cover_image_url
+    created_at
+    external_organization_id
+    homepage_url
+    title
+  }
+}

--- a/src/api/rcos/projects/get_by_id.rs
+++ b/src/api/rcos/projects/get_by_id.rs
@@ -1,0 +1,35 @@
+//! GraphQL query to get a project by its ID.
+
+use crate::api::rcos::prelude::*;
+use crate::api::rcos::send_query;
+use crate::error::TelescopeError;
+
+/// Type representing public RCOS projects.
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "graphql/rcos/schema.json",
+    query_path = "graphql/rcos/projects/get_by_id.graphql",
+    response_derives = "Debug,Clone,Serialize"
+)]
+pub struct Project;
+
+use self::project::{ProjectProject, Variables};
+
+impl Project {
+    /// Get a Project by its ID.
+    pub async fn get(project_id: i64) -> Result<Option<ProjectProject>, TelescopeError> {
+        Ok(send_query::<Self>(Variables { id: project_id })
+            // Wait for API response
+            .await?
+            // Extract the project object.
+            .project)
+    }
+}
+
+impl ProjectProject{
+    /// Get the title of this project. This is the user-defined title if there is one, otherwise
+    /// a title is constructed from the start date and project type.
+    pub fn title(&self) -> String {
+        self.title.clone()
+    }
+}

--- a/src/api/rcos/projects/mod.rs
+++ b/src/api/rcos/projects/mod.rs
@@ -1,3 +1,4 @@
 //! RCOS API interactions related to projects.
 
 pub mod projects_page;
+pub mod get_by_id;

--- a/src/env.rs
+++ b/src/env.rs
@@ -67,6 +67,9 @@ struct TelescopeConfig {
     /// The URL that Telescope is running at. This is used in Discord embeds
     /// and the Open Graph Protocol meta tags. Should not end with a slash.
     telescope_url: Option<String>,
+
+    /// IP address and port to listen on
+    address: Option<String>,
 }
 
 /// A concrete config found by searching the specified profile and parents
@@ -88,6 +91,8 @@ pub struct ConcreteConfig {
     pub telescope_url: String,
     /// The JWT secret used to authenticate with the central API.
     pub jwt_secret: String,
+    /// IP address and port to listen on
+    pub address: String,
 }
 
 impl TelescopeConfig {
@@ -132,6 +137,9 @@ impl TelescopeConfig {
             telescope_url: self
                 .reverse_lookup(profile_slice, |c| c.telescope_url.clone())
                 .expect("Could not resolve Telescope URl."),
+            address: self
+                .reverse_lookup(profile_slice, |c| c.address.clone())
+                .expect("Could not resolve address to bind on."),
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,8 +92,8 @@ async fn main() -> std::io::Result<()> {
             .default_service(aweb::to(web::services::not_found::not_found))
     })
     // Bind to 80 (this gets reversed proxied by Caddy later)
-    .bind("0.0.0.0:80")
-    .expect("Could not bind http://localhost:80")
+    .bind(&env::CONFIG.address)
+    .expect(&format!("Could not bind http://{}", env::CONFIG.address))
     // Start the server running.
     .run();
 

--- a/src/web/services/projects/mod.rs
+++ b/src/web/services/projects/mod.rs
@@ -3,8 +3,10 @@
 use actix_web::web::ServiceConfig;
 
 mod projects_page;
+mod view;
 
 /// Register project services.
 pub fn register(conf: &mut ServiceConfig) {
     conf.service(projects_page::get);
+    conf.service(view::project);
 }

--- a/src/web/services/projects/projects_page.rs
+++ b/src/web/services/projects/projects_page.rs
@@ -1,9 +1,16 @@
 //! Project page.
-
+use crate::api::rcos::projects::projects_page;
 use crate::error::TelescopeError;
-use actix_web::HttpResponse;
+use crate::templates::page::Page;
+use crate::templates::Template;
+use actix_web::HttpRequest;
+
+const TEMPLATE_PATH: &'static str = "projects/list";
 
 #[get("/projects")]
-pub async fn get() -> Result<HttpResponse, TelescopeError> {
-    return Err(TelescopeError::NotImplemented);
+pub async fn get(req: HttpRequest) -> Result<Page, TelescopeError> {
+    let projects = projects_page::AllProjects::get(0, None).await?;
+    let mut template = Template::new(TEMPLATE_PATH);
+    template.fields = json!({ "projects": projects.projects });
+    return template.in_page(&req, "RCOS Projects").await;
 }

--- a/src/web/services/projects/view.rs
+++ b/src/web/services/projects/view.rs
@@ -1,0 +1,49 @@
+use crate::templates::page::Page;
+use crate::templates::tags::Tags;
+use crate::templates::Template;
+use actix_web::web::Path;
+use actix_web::HttpRequest;
+use crate::error::TelescopeError;
+use crate::api::rcos::projects::get_by_id::{project::ProjectProject, Project};
+
+const TEMPLATE_PATH: &'static str = "projects/page";
+
+#[get("/project/{project_id}")]
+pub async fn project(
+    req: HttpRequest,
+    Path(project_id): Path<i64>,
+) -> Result<Page, TelescopeError> {
+    let project: Option<ProjectProject> = Project::get(project_id).await?;
+
+    if project.is_none() {
+        return Err(TelescopeError::resource_not_found(
+                "Project Not Found",
+                "Could not find a Project for this ID.",
+                ));
+    }
+
+    let project = project.unwrap();
+
+
+    let mut template = Template::new(TEMPLATE_PATH);
+    template.fields = json!({
+        "project": &project,
+    });
+
+    let mut tags = Tags::default();
+    // Set title and URL trivially.
+    tags.title = project.title();
+    dbg!(&tags.title);
+    tags.url = req.uri().to_string();
+
+    // tags.description = project.description.clone();
+    // dbg!(&tags.description);
+
+    // Build page around meeting template.
+    let mut page = template.in_page(&req, project.title()).await?;
+    // Replace default page tags with meeting specific ones.
+    page.ogp_tags = tags;
+    // Return page.
+    return Ok(page);
+}
+

--- a/templates/projects/card.hbs
+++ b/templates/projects/card.hbs
@@ -1,0 +1,29 @@
+{{! Project card template -- this is used in the project list and on user profiles }}
+
+<div class="card my-2" id="project-{{project_id}}" style="border-color: var(--meeting-{{type}}-bg); border-width: 4px;">
+    <h3 class="card-header"
+        style="background: {{#if cover_image_url}}url({{cover_image_url}}){{else}}var(--red){{/if}}; border-radius: 0;">
+        {{title}}
+        <span class="float-right">
+            <a href="/project/{{project_id}}" class="btn btn-primary">
+                View Details
+            </a>
+        </span>
+    </h3>
+
+    <div class="list-group list-group-flush text-dark">
+        {{#with most_recent_pm}}
+            <div class="list-group-item">
+                    <span class="text-muted">
+                        Hosted by <a href="/user/{{user.id}}">{{first_name}} {{last_name}}</a>
+                    </span>
+            </div>
+        {{/with}}
+
+        {{#if description}}
+            <div class="list-group-item">
+                {{render_markdown description}}
+            </div>
+        {{/if}}
+    </div>
+</div>

--- a/templates/projects/list.hbs
+++ b/templates/projects/list.hbs
@@ -1,0 +1,10 @@
+<h1>RCOS Projects</h1>
+
+{{#each projects}}
+    {{> projects/card this}}
+{{else}}
+    {{! No meetings -- display a message }}
+    <div class="justify-content-center">
+        Could not find any projects matching these parameters.
+    </div>
+{{/each}}

--- a/templates/projects/page.hbs
+++ b/templates/projects/page.hbs
@@ -1,0 +1,41 @@
+{{! Project page template }}
+<!--<h1>{{> projects/title project}}</h1>-->
+<h1>{{project.title}}</h1>
+
+{{! Description Card }}
+<div class="col-12 col-lg-8">
+    <div class="card text-dark">
+        <div class="card-header">
+            <h4 class="m-0">Description</h4>
+        </div>
+
+        <div class="card-body">
+            {{#if project.description}}
+                {{render_markdown project.description}}
+            {{else}}
+                <span class="font-italic text-muted">
+                    No Description Available.
+                </span>
+            {{/if}}
+        </div>
+    </div>
+</div>
+
+{{! Stack Card }}
+<div class="col-12 col-lg-8">
+    <div class="card text-dark">
+        <div class="card-header">
+            <h4 class="m-0">Description</h4>
+        </div>
+
+        <div class="card-body">
+            {{#if project.description}}
+                {{render_markdown project.description}}
+            {{else}}
+                <span class="font-italic text-muted">
+                    No Description Available.
+                </span>
+            {{/if}}
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
I added new config files, a new config option, and new documentation to support
running Telescope outside of docker. This is useful because compile iteration
time is much faster when not having to rebuild all modules of Telescope.