### PR TITLE
enrollments panel progress

### DIFF
--- a/graphql/rcos/semesters/current/info.graphql
+++ b/graphql/rcos/semesters/current/info.graphql
@@ -1,11 +1,34 @@
 query CurrentSemesters($now: date!) {
-    # Get all semesters containing the current date, as supplied in the
-    # query parameters.
-    semesters(where: {
-        start_date: {_lte: $now},
-        end_date: {_gte: $now}}
-    ) {
-        semester_id
-        title
+  semesters(where: {start_date: {_lte: $now}, end_date: {_gte: $now}}) {
+    start_date
+    end_date
+    semester_id
+    title
+    project_pitches {
+      proposal_url
+      user {
+        first_name
+        last_name
+        id
+      }
     }
+    meetings {
+      meeting_id
+    }
+    project_pitches_aggregate {
+      aggregate {
+        count
+      }
+    }
+    meetings_aggregate {
+      aggregate {
+        count
+      }
+    }
+    enrollments_aggregate {
+      aggregate {
+        count
+      }
+    }
+  }
 }

--- a/graphql/rcos/users/enrollments/edit_enrollment.graphql
+++ b/graphql/rcos/users/enrollments/edit_enrollment.graphql
@@ -1,12 +1,12 @@
 mutation EditEnrollment($semester_id: String!,
   $user_id: uuid!,
-  $credits: Int!
+  $credits: Int,
 	$pay: Boolean!,
 	$coordinator: Boolean!,
 	$lead: Boolean!,
-	$mid_grade: Float!,
-	$final_grade: Float!,
-	$project: Int!) {
+	$mid_grade: Float,
+	$final_grade: Float,
+	$project: Int) {
   update_enrollments_by_pk(
     pk_columns: {
       semester_id: $semester_id,

--- a/graphql/rcos/users/enrollments/edit_enrollment.graphql
+++ b/graphql/rcos/users/enrollments/edit_enrollment.graphql
@@ -1,0 +1,27 @@
+mutation EditEnrollment($semester_id: String!,
+  $user_id: uuid!,
+  $credits: Int!
+	$pay: Boolean!,
+	$coordinator: Boolean!,
+	$lead: Boolean!,
+	$mid_grade: Float!,
+	$final_grade: Float!,
+	$project: Int!) {
+  update_enrollments_by_pk(
+    pk_columns: {
+      semester_id: $semester_id,
+      user_id: $user_id
+    },
+    _set: {
+      credits: $credits,
+      is_coordinator: $coordinator,
+      is_for_pay: $pay,
+      is_project_lead: $lead,
+      mid_year_grade: $mid_grade,
+      project_id: $project,
+      final_grade: $final_grade
+    }) {
+    user_id
+  }
+}
+

--- a/graphql/rcos/users/enrollments/enrollment_by_ids.graphql
+++ b/graphql/rcos/users/enrollments/enrollment_by_ids.graphql
@@ -1,0 +1,24 @@
+query EnrollmentByIds(
+    $semester_id: String!,
+    $user_id: uuid!,
+){
+  enrollments_by_pk(semester_id: $semester_id, user_id: $user_id) {
+    final_grade
+    is_for_pay
+    is_coordinator
+    is_project_lead
+    mid_year_grade
+    project_id,
+    user {
+      first_name
+      last_name
+    }
+    semester {
+      title
+    }
+  }
+  projects(where: {_or: {}}) {
+    title
+  }
+}
+

--- a/graphql/rcos/users/enrollments/enrollment_by_ids.graphql
+++ b/graphql/rcos/users/enrollments/enrollment_by_ids.graphql
@@ -18,6 +18,7 @@ query EnrollmentByIds(
     }
   }
   projects(where: {_or: {}}) {
+    project_id
     title
   }
 }

--- a/graphql/rcos/users/enrollments/enrollment_by_ids.graphql
+++ b/graphql/rcos/users/enrollments/enrollment_by_ids.graphql
@@ -4,6 +4,7 @@ query EnrollmentByIds(
 ){
   enrollments_by_pk(semester_id: $semester_id, user_id: $user_id) {
     final_grade
+    credits
     is_for_pay
     is_coordinator
     is_project_lead

--- a/graphql/rcos/users/profile.graphql
+++ b/graphql/rcos/users/profile.graphql
@@ -27,6 +27,8 @@ query Profile($target: uuid!, $viewer: [uuid!]!, $now: date!) {
             credits
             is_for_pay
             is_project_lead
+            mid_year_grade
+            final_grade
         }
 
         # The user's discord, if it exists

--- a/src/api/rcos/semesters/current/info.rs
+++ b/src/api/rcos/semesters/current/info.rs
@@ -1,6 +1,8 @@
 //! GraphQL query for info about the current semester.
 
-use crate::api::rcos::prelude::*;
+use crate::api::rcos::{prelude::*, send_query};
+use crate::error::TelescopeError;
+use chrono::prelude::*;
 
 /// Type representing GraphQL query for current semester data.
 #[derive(GraphQLQuery)]
@@ -10,3 +12,12 @@ use crate::api::rcos::prelude::*;
     response_derives = "Debug,Clone,Serialize"
 )]
 pub struct CurrentSemesters;
+
+impl CurrentSemesters{
+    pub async fn get() -> Result<current_semesters::ResponseData, TelescopeError> {
+        send_query::<Self>(current_semesters::Variables{
+            now: Utc::now().naive_utc().date(),
+        })
+        .await
+    }
+}

--- a/src/api/rcos/users/enrollments/edit_enrollment.rs
+++ b/src/api/rcos/users/enrollments/edit_enrollment.rs
@@ -1,0 +1,22 @@
+//! Meeting edit mutation and host selection query.
+
+use crate::api::rcos::prelude::*;
+use crate::api::rcos::send_query;
+use crate::error::TelescopeError;
+
+/// Type representing GraphQL enrollment edit mutation.
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "graphql/rcos/schema.json",
+    query_path = "graphql/rcos/users/enrollments/edit_enrollment.graphql",
+    response_derives = "Debug,Copy,Clone,Serialize"
+)]
+pub struct EditEnrollment;
+
+impl EditEnrollment{
+    pub async fn execute(vars: edit_enrollment::Variables) -> Result<Option<uuid>, TelescopeError>{
+       send_query::<Self>(vars)
+           .await
+           .map(|response| response.update_enrollments_by_pk.map(|obj| obj.user_id))
+    }
+}

--- a/src/api/rcos/users/enrollments/enrollment_by_ids.rs
+++ b/src/api/rcos/users/enrollments/enrollment_by_ids.rs
@@ -1,0 +1,24 @@
+use crate::error::TelescopeError;
+use crate::api::rcos::{prelude::*, send_query};
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "graphql/rcos/schema.json",
+    query_path = "graphql/rcos/users/enrollments/enrollment_by_ids.graphql",
+    response_derives = "Debug,Clone,Serialize"
+)]
+
+pub struct EnrollmentByIds;
+
+impl EnrollmentByIds {
+    pub async fn get(
+        user_id: uuid,
+        semester_id: String,
+        ) -> Result<enrollment_by_ids::ResponseData, TelescopeError> {
+        send_query::<Self>(enrollment_by_ids::Variables {
+            semester_id,
+            user_id,
+        })
+        .await
+    }
+}

--- a/src/api/rcos/users/enrollments/mod.rs
+++ b/src/api/rcos/users/enrollments/mod.rs
@@ -3,3 +3,4 @@
 pub mod enrollments_lookup;
 pub mod user_enrollment_lookup;
 pub mod enrollment_by_ids;
+pub mod edit_enrollment;

--- a/src/api/rcos/users/enrollments/mod.rs
+++ b/src/api/rcos/users/enrollments/mod.rs
@@ -2,3 +2,4 @@
 
 pub mod enrollments_lookup;
 pub mod user_enrollment_lookup;
+pub mod enrollment_by_ids;

--- a/src/api/rcos/users/mod.rs
+++ b/src/api/rcos/users/mod.rs
@@ -79,11 +79,6 @@ impl UserRole {
         self == UserRole::Sysadmin || self == UserRole::FacultyAdvisor
     }
 
-    //TEMPORARY
-    pub fn is_coordinator(self) -> bool {
-        self == UserRole::Sysadmin || self == UserRole::FacultyAdvisor
-    }
-
     /// Does this role represent an external user or mentor?
     pub fn is_external(self) -> bool {
         self == UserRole::External || self == UserRole::ExternalMentor

--- a/src/api/rcos/users/mod.rs
+++ b/src/api/rcos/users/mod.rs
@@ -79,6 +79,11 @@ impl UserRole {
         self == UserRole::Sysadmin || self == UserRole::FacultyAdvisor
     }
 
+    //TEMPORARY
+    pub fn is_coordinator(self) -> bool {
+        self == UserRole::Sysadmin || self == UserRole::FacultyAdvisor
+    }
+
     /// Does this role represent an external user or mentor?
     pub fn is_external(self) -> bool {
         self == UserRole::External || self == UserRole::ExternalMentor

--- a/src/web/services/coordinate/enrollments/edit.rs
+++ b/src/web/services/coordinate/enrollments/edit.rs
@@ -10,6 +10,11 @@ use crate::api::rcos::prelude::*;
 
 const ENROLLMENT_EDIT_FORM: &str = "coordinate/enrollments/edit/form";
 
+
+//there is one potential issue with this page, a coordinator probably shouldn't be able to edit
+//their own enrollment or the enrollments of other coordinators, while there won't be an edit
+//button on those restricted enrollments for coordinators, they can access the edit page for those
+//enrollments if they put in the url directly.  I don't have a solution for this right now
 pub fn register(config: &mut ServiceConfig){
     config
         .service(edit_page)
@@ -70,8 +75,6 @@ Form(form_data): Form<EnrollmentForm>,
     //Consider changing later?
     let enrollment_data =  EnrollmentByIds::get(uid, semester_id).await?;
    
-    dbg!("{}", &enrollment_data);
-
     let mut form = Template::new(ENROLLMENT_EDIT_FORM);
     form.fields = json!({
         "data": enrollment_data,

--- a/src/web/services/coordinate/enrollments/edit.rs
+++ b/src/web/services/coordinate/enrollments/edit.rs
@@ -1,35 +1,29 @@
 use crate::error::TelescopeError;
 use crate::templates::page::Page;
-use crate::api::rcos::users::enrollments::{
-    enrollment_by_ids::{EnrollmentByIds},
-};
-use crate::api::rcos::projects::projects_page::CurrentProjects;
+use crate::api::rcos::users::enrollments::enrollment_by_ids::EnrollmentByIds;
 use crate::templates::Template;
 use actix_web::web::Form;
-use actix_web::http::header::LOCATION;
-use chrono::{DateTime, Local, NaiveDateTime, NaiveTime, TimeZone, Utc};
-use serde_json::Value;
-use actix_web::web::{self as aweb, Path, Query, ServiceConfig, HttpRequest};
+use crate::api::rcos::users::enrollments::edit_enrollment::edit_enrollment::Variables;
+use crate::api::rcos::users::enrollments::edit_enrollment;
+use actix_web::web::{Path, ServiceConfig, HttpRequest};
 use crate::api::rcos::prelude::*;
 
 const ENROLLMENT_EDIT_FORM: &str = "coordinate/enrollments/edit/form";
 
 pub fn register(config: &mut ServiceConfig){
-    config.route(
-        "/semesters/enrollments/{semester_id}/{user_id}/edit",
-        aweb::get().to(edit_page),
-                 );
+    config
+        .service(edit_page)
+        .service(submit_edits);
 }
 
+#[get("/semesters/enrollments/{semester_id}/{user_id}/edit")]
 pub async fn edit_page(
 req: HttpRequest,
 Path((semester_id, user_id)): Path<(String, String)>,
 ) -> Result<Page, TelescopeError>{
-    let uid = user_id.parse::<uuid>().ok().unwrap();
-    let enrollment_data =  EnrollmentByIds::get(uid, semester_id).await?;
+    let uuid = user_id.parse::<uuid>().ok().unwrap();
+    let enrollment_data =  EnrollmentByIds::get(uuid, semester_id).await?;
    
-    dbg!("{}", &enrollment_data);
-
     let mut form = Template::new(ENROLLMENT_EDIT_FORM);
     form.fields = json!({
         "data": enrollment_data,
@@ -39,6 +33,73 @@ Path((semester_id, user_id)): Path<(String, String)>,
     form.in_page(&req, "Edit Enrollment").await
 }
 
-pub async fn submit_edits(){
+#[post("/semesters/enrollments/{semester_id}/{user_id}/edit")]
+pub async fn submit_edits(
+req: HttpRequest,
+Path((semester_id, user_id)): Path<(String, String)>,
+Form(form_data): Form<EnrollmentForm>,
+) -> Result<Page, TelescopeError>{
+    let uid = user_id.parse::<uuid>().ok().unwrap();
 
+    let EnrollmentForm {
+        lead,
+        coordinator,
+        pay,
+        project,
+        credit,
+        mid_grade,
+        final_grade,
+    } = form_data;
+    let uuid = user_id.parse::<uuid>().ok().unwrap();
+
+    let edit_variables = Variables {
+        semester_id: semester_id.clone(),
+        user_id: uuid,
+        lead,
+        coordinator,
+        pay,
+        project: project.unwrap(),
+        credits: credit.unwrap(),
+        mid_grade: mid_grade.unwrap(),
+        final_grade: final_grade.unwrap(),
+    };
+
+    let _user_id = edit_enrollment::EditEnrollment::execute(edit_variables).await;
+
+    //We make another request here immediately after editing it, maybe not ideal speed wise.
+    //Consider changing later?
+    let enrollment_data =  EnrollmentByIds::get(uid, semester_id).await?;
+   
+    dbg!("{}", &enrollment_data);
+
+    let mut form = Template::new(ENROLLMENT_EDIT_FORM);
+    form.fields = json!({
+        "data": enrollment_data,
+    });
+
+    form.in_page(&req, "Edit Enrollment").await
+
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct EnrollmentForm { 
+    #[serde(default)]
+    pub lead: bool,
+
+    #[serde(default)]
+    pub coordinator: bool,
+
+    #[serde(default)]
+    pub pay: bool,
+
+    #[serde(default)]
+    pub mid_grade: Option<f64>,
+
+    #[serde(default)]
+    pub final_grade: Option<f64>,
+
+    #[serde(default)]
+    pub credit: Option<i64>,
+
+    pub project: Option<i64>, 
 }

--- a/src/web/services/coordinate/enrollments/edit.rs
+++ b/src/web/services/coordinate/enrollments/edit.rs
@@ -31,7 +31,6 @@ Path((semester_id, user_id)): Path<(String, String)>,
 ) -> Result<Page, TelescopeError>{
     let uuid = user_id.parse::<uuid>().ok().unwrap();
     let enrollment_data =  EnrollmentByIds::get(uuid, semester_id).await?;
-    dbg!(enrollment_data.clone());
    
     let mut form = Template::new(ENROLLMENT_EDIT_FORM);
     form.fields = json!({

--- a/src/web/services/coordinate/enrollments/edit.rs
+++ b/src/web/services/coordinate/enrollments/edit.rs
@@ -1,0 +1,44 @@
+use crate::error::TelescopeError;
+use crate::templates::page::Page;
+use crate::api::rcos::users::enrollments::{
+    enrollment_by_ids::{EnrollmentByIds},
+};
+use crate::api::rcos::projects::projects_page::CurrentProjects;
+use crate::templates::Template;
+use actix_web::web::Form;
+use actix_web::http::header::LOCATION;
+use chrono::{DateTime, Local, NaiveDateTime, NaiveTime, TimeZone, Utc};
+use serde_json::Value;
+use actix_web::web::{self as aweb, Path, Query, ServiceConfig, HttpRequest};
+use crate::api::rcos::prelude::*;
+
+const ENROLLMENT_EDIT_FORM: &str = "coordinate/enrollments/edit/form";
+
+pub fn register(config: &mut ServiceConfig){
+    config.route(
+        "/semesters/enrollments/{semester_id}/{user_id}/edit",
+        aweb::get().to(edit_page),
+                 );
+}
+
+pub async fn edit_page(
+req: HttpRequest,
+Path((semester_id, user_id)): Path<(String, String)>,
+) -> Result<Page, TelescopeError>{
+    let uid = user_id.parse::<uuid>().ok().unwrap();
+    let enrollment_data =  EnrollmentByIds::get(uid, semester_id).await?;
+   
+    dbg!("{}", &enrollment_data);
+
+    let mut form = Template::new(ENROLLMENT_EDIT_FORM);
+    form.fields = json!({
+        "data": enrollment_data,
+    });
+
+    
+    form.in_page(&req, "Edit Enrollment").await
+}
+
+pub async fn submit_edits(){
+
+}

--- a/src/web/services/coordinate/enrollments/edit.rs
+++ b/src/web/services/coordinate/enrollments/edit.rs
@@ -48,7 +48,7 @@ req: HttpRequest,
 Path((semester_id, user_id)): Path<(String, String)>,
 Form(form_data): Form<EnrollmentForm>,
 ) -> Result<Page, TelescopeError>{
-    let uid = user_id.parse::<uuid>().ok().unwrap();
+    let uuid = user_id.parse::<uuid>().ok().unwrap();
 
     let EnrollmentForm {
         lead,
@@ -59,7 +59,6 @@ Form(form_data): Form<EnrollmentForm>,
         mid_grade,
         final_grade,
     } = form_data;
-    let uuid = user_id.parse::<uuid>().ok().unwrap();
 
     let edit_variables = Variables {
         semester_id: semester_id.clone(),
@@ -77,7 +76,7 @@ Form(form_data): Form<EnrollmentForm>,
 
     //We make another request here immediately after editing it, maybe not ideal speed wise.
     //Consider changing later?
-    let enrollment_data =  EnrollmentByIds::get(uid, semester_id).await?;
+    let enrollment_data =  EnrollmentByIds::get(uuid, semester_id).await?;
    
     let mut form = Template::new(ENROLLMENT_EDIT_FORM);
     form.fields = json!({

--- a/src/web/services/coordinate/enrollments/edit.rs
+++ b/src/web/services/coordinate/enrollments/edit.rs
@@ -87,6 +87,7 @@ Form(form_data): Form<EnrollmentForm>,
 }
 
 // Modification of a snippet found on an Actix Web github issue. Helps with null value numbers
+// https://github.com/actix/actix-web/issues/1815#issuecomment-740266354
 pub fn deserialize_option_ignore_error<'de, T, D>(d: D) -> Result<Option<T>, D::Error>
 where
     T: de::Deserialize<'de>,

--- a/src/web/services/coordinate/enrollments/mod.rs
+++ b/src/web/services/coordinate/enrollments/mod.rs
@@ -102,7 +102,7 @@ pub async fn enrollments_page_index(
                 .expect("Viewer's account does not exist");
             is_not_administrator = !role.is_admin();
         },
-        None => is_not_administrator = false, 
+        None => is_not_administrator = true, 
     };
     
     template.fields = json!({

--- a/src/web/services/coordinate/enrollments/mod.rs
+++ b/src/web/services/coordinate/enrollments/mod.rs
@@ -35,6 +35,10 @@ pub fn register(config: &mut ServiceConfig) {
         "/semesters/enrollments/{semester_id}/{page}",
         aweb::get().to(enrollments_page_index),
     );
+    config.route(
+        "/semesters/enrollments/{semester_id}",
+        aweb::get().to(enrollments_page_index),
+    );
 }
 
 fn get_page_numbers(api_response: &Value, current_page: u64) -> Option<PaginationInfo> {
@@ -92,7 +96,7 @@ pub async fn enrollments_page_index(
 
     // Get the viewers user ID
     let viewer: Option<Uuid> = identity.get_user_id().await?;
-    let prefix = "/admin/semesters/enrollments/".to_owned() + &semester_id + "/";
+    let prefix = "/coordinate/semesters/enrollments/".to_owned() + &semester_id + "/";
     let mut template = Template::new(TEMPLATE_PATH);
     let is_not_administrator: bool;
     match viewer {

--- a/src/web/services/coordinate/enrollments/mod.rs
+++ b/src/web/services/coordinate/enrollments/mod.rs
@@ -1,0 +1,119 @@
+use actix_web::web::{self as aweb, Path, Query, ServiceConfig};
+use actix_web::HttpRequest;
+use chrono::Utc;
+use serde_json::Value;
+use uuid::Uuid;
+
+use crate::api::rcos::semesters::get_by_id::Semester;
+use crate::api::rcos::users::role_lookup::RoleLookup;
+use crate::api::rcos::users::UserRole;
+use crate::api::rcos::semesters::get_by_id::semester::SemesterSemestersByPk;
+use crate::error::TelescopeError;
+use crate::api::rcos::users::enrollments::user_enrollment_lookup::UserEnrollmentLookup;
+use crate::templates::page::Page;
+use crate::templates::pagination::PaginationInfo;
+use crate::templates::Template;
+use crate::web::services::auth::identity::Identity;
+use crate::api::rcos::semesters::get::PER_PAGE;
+
+//mod create;
+mod edit;
+
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+pub struct EnrollmentPageQuery {
+    /// Filter for users if their first name, last name, or RCS ID contains
+    /// this string case independently (via ILIKE).
+    pub search: Option<String>,
+}
+
+const TEMPLATE_PATH: &str = "coordinate/enrollments/index";
+
+//Register enrollment management
+pub fn register(config: &mut ServiceConfig) {
+    edit::register(config);
+    config.route(
+        "/semesters/enrollments/{semester_id}/{page}",
+        aweb::get().to(enrollments_page_index),
+    );
+}
+
+fn get_page_numbers(api_response: &Value, current_page: u64) -> Option<PaginationInfo> {
+    api_response
+        // Check for the JSON field user_count
+        .get("user_count")?
+        // With field aggregate
+        .get("aggregate")?
+        // With field count
+        .get("count")?
+        // As an unsigned integer
+        .as_u64()
+        // Convert to pagination info
+        .and_then(|count| PaginationInfo::new(count, PER_PAGE as u64, current_page))
+}
+
+pub async fn enrollments_page_index(
+    req: HttpRequest,
+    identity: Identity,
+    Path((semester_id, page)): Path<(String, u32)>,
+    Query(query): Query<EnrollmentPageQuery>,
+) -> Result<Page, TelescopeError>{
+    let mut page_num = page;
+    if page_num >= 1{
+        page_num -= 1;
+    }
+    else{
+        page_num = 0;
+    }
+
+    let semester = Semester::get_by_id(semester_id.clone())
+        .await?
+        .unwrap_or_else(|| SemesterSemestersByPk {
+            semester_id: semester_id.clone(),
+            title: "".to_string(),
+            start_date: Utc::today().naive_utc(),
+            end_date: Utc::today().naive_utc(),
+        });
+    let query_response =
+        UserEnrollmentLookup::get_by_id(page_num, query.search.clone(), semester_id.clone())
+            .await?;
+    let enrollments = query_response.enrollments.clone();
+    let enrollment_data = serde_json::to_value(enrollments).map_err(|e| {
+        TelescopeError::ise(format!(
+            "Could not serialize enrollments data to JSON format: {}",
+            e
+        ))
+    })?;
+    let api_data = serde_json::to_value(query_response).map_err(|e| {
+        TelescopeError::ise(format!(
+            "Could not serialize API data to JSON format: {}",
+            e
+        ))
+    })?;
+
+    // Get the viewers user ID
+    let viewer: Option<Uuid> = identity.get_user_id().await?;
+    let prefix = "/admin/semesters/enrollments/".to_owned() + &semester_id + "/";
+    let mut template = Template::new(TEMPLATE_PATH);
+    let is_not_administrator: bool;
+    match viewer {
+        Some(x) => {
+            let role: UserRole = RoleLookup::get(x)
+                .await?
+                .expect("Viewer's account does not exist");
+            is_not_administrator = !role.is_admin();
+        },
+        None => is_not_administrator = false, 
+    };
+    
+    template.fields = json!({
+        "pagination": get_page_numbers(&api_data, page_num as u64 + 1),
+        "title": semester.title,
+        "data": enrollment_data,
+        "semester_id": semester_id,
+        "identity": viewer,
+        "prefix": prefix,
+        "preserved_query_string": req.query_string(),
+        "is_not_admin": is_not_administrator,
+    });
+    template.in_page(&req, "Enrollments").await
+} 

--- a/src/web/services/coordinate/enrollments/mod.rs
+++ b/src/web/services/coordinate/enrollments/mod.rs
@@ -14,7 +14,7 @@ use crate::templates::page::Page;
 use crate::templates::pagination::PaginationInfo;
 use crate::templates::Template;
 use crate::web::services::auth::identity::Identity;
-use crate::api::rcos::semesters::get::PER_PAGE;
+use crate::api::rcos::users::enrollments::user_enrollment_lookup::PER_PAGE;
 
 //mod create;
 mod edit;
@@ -108,7 +108,6 @@ pub async fn enrollments_page_index(
         },
         None => is_not_administrator = true, 
     };
-    
     template.fields = json!({
         "pagination": get_page_numbers(&api_data, page_num as u64 + 1),
         "title": semester.title,

--- a/src/web/services/coordinate/mod.rs
+++ b/src/web/services/coordinate/mod.rs
@@ -1,0 +1,62 @@
+//mod enrollments;
+//mod project_pitches;
+//mod meetings;
+
+use crate::api::rcos::users::role_lookup::RoleLookup;
+use crate::api::rcos::users::UserRole;
+use crate::error::TelescopeError;
+use crate::templates::page::Page;
+use crate::templates::Template;
+use crate::api::rcos::semesters::current::info::CurrentSemesters;
+use crate::web::middlewares::authorization::{Authorization, AuthorizationResult};
+use actix_web::guard;
+use actix_web::web as aweb;
+use actix_web::web::ServiceConfig;
+use actix_web::HttpRequest;
+use futures::future::LocalBoxFuture;
+use uuid::Uuid;
+
+fn coordinator_authorization(user_id: Uuid) -> LocalBoxFuture<'static, AuthorizationResult>{
+    Box::pin(async move{
+        //check that user is a coordinator+
+        let role: UserRole = RoleLookup::get(user_id)
+            .await?
+            .expect("Viewer's account does not exist.");
+
+        //forbid access if not the case
+        if !role.is_coordinator() {
+            Err(TelescopeError::Forbidden)
+        } else {
+            Ok(())
+        }
+    })
+}
+
+pub fn register(config: &mut ServiceConfig) {
+    //Create coordinator auth middleware
+    let coordinator_authorization_middleware: Authorization = Authorization::new(coordinator_authorization);
+    
+    //Coordinator Panel index page.
+    config.service(
+        aweb::resource("/coordinate")
+        .guard(guard::Get())
+        .wrap(coordinator_authorization_middleware.clone())
+        .to(index),
+        );
+
+    config.service(
+        aweb::scope("/coordinate/")
+        .wrap(coordinator_authorization_middleware)
+//        .configure(semesters::register),
+        );
+}
+
+async fn index(req: HttpRequest) -> Result<Page, TelescopeError> {
+    let current_semester_data = CurrentSemesters::get().await?; 
+
+    let mut template = Template::new("coordinate/index");
+    template.fields = json!({
+        "data": current_semester_data,
+    });
+    template.in_page(&req, "Current Semesters").await
+}

--- a/src/web/services/coordinate/mod.rs
+++ b/src/web/services/coordinate/mod.rs
@@ -1,7 +1,3 @@
-//mod enrollments;
-//mod project_pitches;
-//mod meetings;
-
 use crate::api::rcos::users::role_lookup::RoleLookup;
 use crate::api::rcos::users::UserRole;
 use crate::error::TelescopeError;
@@ -15,6 +11,10 @@ use actix_web::web::ServiceConfig;
 use actix_web::HttpRequest;
 use futures::future::LocalBoxFuture;
 use uuid::Uuid;
+
+mod enrollments;
+//mod project_pitches;
+//mod meetings;
 
 fn coordinator_authorization(user_id: Uuid) -> LocalBoxFuture<'static, AuthorizationResult>{
     Box::pin(async move{
@@ -35,6 +35,7 @@ fn coordinator_authorization(user_id: Uuid) -> LocalBoxFuture<'static, Authoriza
 pub fn register(config: &mut ServiceConfig) {
     //Create coordinator auth middleware
     let coordinator_authorization_middleware: Authorization = Authorization::new(coordinator_authorization);
+
     
     //Coordinator Panel index page.
     config.service(
@@ -47,6 +48,7 @@ pub fn register(config: &mut ServiceConfig) {
     config.service(
         aweb::scope("/coordinate/")
         .wrap(coordinator_authorization_middleware)
+        .configure(enrollments::register)
 //        .configure(semesters::register),
         );
 }

--- a/src/web/services/mod.rs
+++ b/src/web/services/mod.rs
@@ -3,6 +3,7 @@
 use actix_web::web::ServiceConfig;
 
 mod admin;
+mod coordinate;
 pub mod auth;
 mod index;
 pub mod meetings;
@@ -26,6 +27,9 @@ pub fn register(config: &mut ServiceConfig) {
 
     // Admin panel services.
     admin::register(config);
+
+    // Coordinator panel services.
+    coordinate::register(config);
 
     config
         // Homepage

--- a/src/web/services/user/join_discord.rs
+++ b/src/web/services/user/join_discord.rs
@@ -96,9 +96,8 @@ pub async fn handle(auth: AuthenticationCookie) -> Result<HttpResponse, Telescop
 
     // Add user to Discord with verified role and nickname.
     
-    let nickname_copy = &nickname;
     discord
-        .add_to_rcos_guild(Some(nickname_copy.to_string()), vec![verified_role])
+        .add_to_rcos_guild(Some(nickname.clone()), vec![verified_role])
         .await?;
     
 

--- a/templates/coordinate/enrollments/edit/form.hbs
+++ b/templates/coordinate/enrollments/edit/form.hbs
@@ -10,7 +10,7 @@
             <form method="post">
                 <div class="form-row">
                     <label for="lead-select">Is Project Lead:</label>
-                    <select class="form-control" id="lead-select", name="project-lead" required>
+                    <select class="form-control" id="lead-select", name="lead" required>
                         <option value="true" {{#if is_project_lead}} selected {{/if}}> true </option>
                         <option value="false" {{#unless is_project_lead}} selected {{/unless}}> false </option>
                     </select>
@@ -31,21 +31,21 @@
                 </div>
                 <div class="form-row">
                     <label for="mid-year-grade">Mid Year Grade:</label>
-                    <input id="mid-year-grade" type="number" value="{{mid_year_grade}}"/>
+                    <input id="mid-year-grade" type="number" name="mid_grade" value="{{mid_year_grade}}"/>
                 </div>
                 <div class="form-row">
                     <label for="final_grade">Final Grade:</label>
-                    <input id="final_grade" type="number" value="{{final_grade}}"/>
+                    <input id="final_grade" type="number" name="final_grade" value="{{final_grade}}"/>
                 </div>
                 <div class="form-row">
                     <label for="credit-count">Credit Count:</label>
-                    <input id="credit-count" type="number" value="{{credit}}"/>
+                    <input id="credit-count" type="number" name="credit" value="{{credit}}"/>
                 </div>
                 {{/with}}
                 {{#with data}}
                 <div class="form-row">
                     <label for="project-select">Project:</label>
-                    <select class="form-control" id="project-select">
+                    <select class="form-control" name="project" id="project-select">
                         {{#each projects}}
                             <option value="project_id" {{#if (eq project_id enrollments_by_pk.project_id)}} selected {{/if}}>{{title}}</option>
                         {{/each}}

--- a/templates/coordinate/enrollments/edit/form.hbs
+++ b/templates/coordinate/enrollments/edit/form.hbs
@@ -8,42 +8,42 @@
         </div>
         <div class="card-body">
             <form onsubmit="return alert('Changes Saved!');" method="post">
-                <div class="form-row">
+                <div class="form-group">
                     <label for="lead-select">Is Project Lead:</label>
                     <select class="form-control" id="lead-select", name="lead" required>
                         <option value="true" {{#if is_project_lead}} selected {{/if}}> true </option>
                         <option value="false" {{#unless is_project_lead}} selected {{/unless}}> false </option>
                     </select>
                 </div>
-                <div class="form-row">
+                <div class="form-group">
                     <label for="coordinator-select">Is Coordinator:</label>
                     <select class="form-control" id="coordinator-select", name="coordinator" required>
                         <option value="true" {{#if is_coordinator}} selected {{/if}}> true </option>
                         <option value="false" {{#unless is_coordinator}} selected {{/unless}}> false </option>
                     </select>
                 </div>
-                <div class="form-row">
+                <div class="form-group">
                     <label for="pay-select">Is for Pay:</label>
                     <select class="form-control" id="pay-select", name="pay" required>
                         <option value="true" {{#if is_for_pay}} selected {{/if}}> true </option>
                         <option value="false" {{#unless is_for_pay}} selected {{/unless}}> false </option>
                     </select>
                 </div>
-                <div class="form-row">
+                <div class="form-group">
                     <label for="mid-year-grade">Mid Year Grade:</label>
                     <input id="mid-year-grade" type="number" step="0.01" name="mid_grade" value="{{mid_year_grade}}"/>
                 </div>
-                <div class="form-row">
+                <div class="form-group">
                     <label for="final_grade">Final Grade:</label>
                     <input id="final_grade" type="number" step="0.01" name="final_grade" value="{{final_grade}}"/>
                 </div>
-                <div class="form-row">
+                <div class="form-group">
                     <label for="credit-count">Credit Count:</label>
                     <input id="credit-count" type="number" name="credit" value="{{credits}}"/>
                 </div>
                 {{/with}}
                 {{#with data}}
-                <div class="form-row">
+                <div class="form-group">
                     <label for="project-select">Project:</label>
                     <select class="form-control" name="project" id="project-select">
                         <option>None</option>

--- a/templates/coordinate/enrollments/edit/form.hbs
+++ b/templates/coordinate/enrollments/edit/form.hbs
@@ -7,7 +7,7 @@
            </h1>
         </div>
         <div class="card-body">
-            <form method="post">
+            <form onsubmit="return alert('Changes Saved!');" method="post">
                 <div class="form-row">
                     <label for="lead-select">Is Project Lead:</label>
                     <select class="form-control" id="lead-select", name="lead" required>

--- a/templates/coordinate/enrollments/edit/form.hbs
+++ b/templates/coordinate/enrollments/edit/form.hbs
@@ -31,15 +31,15 @@
                 </div>
                 <div class="form-row">
                     <label for="mid-year-grade">Mid Year Grade:</label>
-                    <input id="mid-year-grade" type="number" name="mid_grade" value="{{mid_year_grade}}"/>
+                    <input id="mid-year-grade" type="number" step="0.01" name="mid_grade" value="{{mid_year_grade}}"/>
                 </div>
                 <div class="form-row">
                     <label for="final_grade">Final Grade:</label>
-                    <input id="final_grade" type="number" name="final_grade" value="{{final_grade}}"/>
+                    <input id="final_grade" type="number" step="0.01" name="final_grade" value="{{final_grade}}"/>
                 </div>
                 <div class="form-row">
                     <label for="credit-count">Credit Count:</label>
-                    <input id="credit-count" type="number" name="credit" value="{{credit}}"/>
+                    <input id="credit-count" type="number" name="credit" value="{{credits}}"/>
                 </div>
                 {{/with}}
                 {{#with data}}
@@ -47,7 +47,7 @@
                     <label for="project-select">Project:</label>
                     <select class="form-control" name="project" id="project-select">
                         {{#each projects}}
-                            <option value="project_id" {{#if (eq project_id enrollments_by_pk.project_id)}} selected {{/if}}>{{title}}</option>
+                            <option value={{project_id}} {{#if (eq project_id ../enrollments_by_pk.project_id)}} selected {{/if}}>{{title}}</option>
                         {{/each}}
                     </select>
                 </div>

--- a/templates/coordinate/enrollments/edit/form.hbs
+++ b/templates/coordinate/enrollments/edit/form.hbs
@@ -1,0 +1,44 @@
+<div class="row justify-content-center no-gutters">
+    {{#with data.enrollments_by_pk}}
+    <div class="card text-dark col-sm-11 col-md-9 col-lg-8">
+        <div class="card-header">
+           <h1 class="card-title">
+                Edit {{user.first_name}} {{user.last_name}}'s enrollment in {{semester.title}}
+           </h1>
+        </div>
+        <div class="card-body">
+            <form method="post">
+                <div class="form-row">
+                    <label for="lead-select">Is Project Lead:</label>
+                    <select class="form-control" id="lead-select", name="project-lead" required>
+                        <option value="true" {{#if is_project_lead}} selected {{/if}}> true </option>
+                        <option value="false" {{#unless is_project_lead}} selected {{/unless}}> false </option>
+                    </select>
+                </div>
+                <div class="form-row">
+                    <label for="coordinator-select">Is Coordinator:</label>
+                    <select class="form-control" id="coordinator-select", name="coordinator" required>
+                        <option value="true" {{#if is_coordinator}} selected {{/if}}> true </option>
+                        <option value="false" {{#unless is_coordinator}} selected {{/unless}}> false </option>
+                    </select>
+                </div>
+                <div class="form-row">
+                    <label for="pay-select">Is for Pay:</label>
+                    <select class="form-control" id="pay-select", name="pay" required>
+                        <option value="true" {{#if is_for_pay}} selected {{/if}}> true </option>
+                        <option value="false" {{#unless is_for_pay}} selected {{/unless}}> false </option>
+                    </select>
+                </div>
+                <div class="form-row">
+                    <label for="mid-year-grade">Mid Year Grade:</label>
+                    <input id="mid-year-grade" type="number" value="{{mid_year_grade}}"/>
+                </div>
+                <div class="form-row">
+                    <label for="final_grade">Final Grade:</label>
+                    <input id="final_grade" type="number" value="{{final_grade}}"/>
+                </div>
+            </form>
+        </div>
+    </div>
+    {{/with}}
+</div>

--- a/templates/coordinate/enrollments/edit/form.hbs
+++ b/templates/coordinate/enrollments/edit/form.hbs
@@ -37,8 +37,25 @@
                     <label for="final_grade">Final Grade:</label>
                     <input id="final_grade" type="number" value="{{final_grade}}"/>
                 </div>
+                <div class="form-row">
+                    <label for="credit-count">Credit Count:</label>
+                    <input id="credit-count" type="number" value="{{credit}}"/>
+                </div>
+                {{/with}}
+                {{#with data}}
+                <div class="form-row">
+                    <label for="project-select">Project:</label>
+                    <select class="form-control" id="project-select">
+                        {{#each projects}}
+                            <option value="project_id" {{#if (eq project_id enrollments_by_pk.project_id)}} selected {{/if}}>{{title}}</option>
+                        {{/each}}
+                    </select>
+                </div>
+                {{/with}}
+                <button type="submit" class="btn btn-success w100">
+                    Save Changes
+                </button>
             </form>
         </div>
     </div>
-    {{/with}}
 </div>

--- a/templates/coordinate/enrollments/edit/form.hbs
+++ b/templates/coordinate/enrollments/edit/form.hbs
@@ -46,6 +46,7 @@
                 <div class="form-row">
                     <label for="project-select">Project:</label>
                     <select class="form-control" name="project" id="project-select">
+                        <option>None</option>
                         {{#each projects}}
                             <option value={{project_id}} {{#if (eq project_id ../enrollments_by_pk.project_id)}} selected {{/if}}>{{title}}</option>
                         {{/each}}

--- a/templates/coordinate/enrollments/edit/form.hbs
+++ b/templates/coordinate/enrollments/edit/form.hbs
@@ -9,48 +9,49 @@
         <div class="card-body">
             <form onsubmit="return alert('Changes Saved!');" method="post">
                 <div class="form-group">
-                    <label for="lead-select">Is Project Lead:</label>
-                    <select class="form-control" id="lead-select", name="lead" required>
-                        <option value="true" {{#if is_project_lead}} selected {{/if}}> true </option>
-                        <option value="false" {{#unless is_project_lead}} selected {{/unless}}> false </option>
-                    </select>
+                    <div class="form-check-inline">
+                        <input class="form-check-input" id="lead-select" name="lead" type="checkbox" value="true" {{#if is_project_lead}} checked {{/if}}/>
+                        <label for="lead-select" class="form-check-label">Project lead</label>
+                    </div>
+                    <div class="form-check-inline">
+                        <input class="form-check-input" id="coordinator-select" name="coordinator" type="checkbox" value="true" {{#if is_coordinator}} checked {{/if}}/>
+                        <label for="coordinator-select" class="form-check-label">Coordinator</label>
+                    </div>
+                    <div class="form-check-inline">
+                        <input class="form-check-input" id="pay-select" name="pay" type="checkbox" value="true" {{#if is_for_pay}} checked {{/if}}/>
+                        <label for="pay-select" class="form-check-label">For pay</label>
+                    </div>
                 </div>
-                <div class="form-group">
-                    <label for="coordinator-select">Is Coordinator:</label>
-                    <select class="form-control" id="coordinator-select", name="coordinator" required>
-                        <option value="true" {{#if is_coordinator}} selected {{/if}}> true </option>
-                        <option value="false" {{#unless is_coordinator}} selected {{/unless}}> false </option>
-                    </select>
+                <div class="form-group row">
+                    <label for="mid-year-grade" class="col-sm-3 col-form-label">Mid-year grade:</label>
+                    <div class="col">
+                        <input class="form-control" id="mid-year-grade" type="number" step="0.01" name="mid_grade" value="{{mid_year_grade}}" />
+                    </div>
                 </div>
-                <div class="form-group">
-                    <label for="pay-select">Is for Pay:</label>
-                    <select class="form-control" id="pay-select", name="pay" required>
-                        <option value="true" {{#if is_for_pay}} selected {{/if}}> true </option>
-                        <option value="false" {{#unless is_for_pay}} selected {{/unless}}> false </option>
-                    </select>
+                <div class="form-group row">
+                    <label for="final_grade" class="col-sm-3 col-form-label">Final grade:</label>
+                    <div class="col">
+                        <input class="form-control" id="final_grade" type="number" step="0.01" name="final_grade" value="{{final_grade}}" />
+                    </div>
                 </div>
-                <div class="form-group">
-                    <label for="mid-year-grade">Mid Year Grade:</label>
-                    <input id="mid-year-grade" type="number" step="0.01" name="mid_grade" value="{{mid_year_grade}}"/>
-                </div>
-                <div class="form-group">
-                    <label for="final_grade">Final Grade:</label>
-                    <input id="final_grade" type="number" step="0.01" name="final_grade" value="{{final_grade}}"/>
-                </div>
-                <div class="form-group">
-                    <label for="credit-count">Credit Count:</label>
-                    <input id="credit-count" type="number" name="credit" value="{{credits}}"/>
+                <div class="form-group row">
+                    <label for="credit-count" class="col-sm-3 col-form-label">Credit count:</label>
+                    <div class="col">
+                        <input class="form-control" id="credit-count" type="number" name="credit" value="{{credits}}" />
+                    </div>
                 </div>
                 {{/with}}
                 {{#with data}}
-                <div class="form-group">
-                    <label for="project-select">Project:</label>
-                    <select class="form-control" name="project" id="project-select">
-                        <option>None</option>
-                        {{#each projects}}
-                            <option value={{project_id}} {{#if (eq project_id ../enrollments_by_pk.project_id)}} selected {{/if}}>{{title}}</option>
-                        {{/each}}
-                    </select>
+                <div class="form-group row">
+                    <label for="project-select" class="col-sm-3 col-form-label">Project:</label>
+                    <div class="col">
+                        <select class="form-control" name="project" id="project-select">
+                            <option>None</option>
+                            {{#each projects}}
+                                <option value={{project_id}} {{#if (eq project_id ../enrollments_by_pk.project_id)}} selected {{/if}}>{{title}}</option>
+                            {{/each}}
+                        </select>
+                    </div>
                 </div>
                 {{/with}}
                 <button type="submit" class="btn btn-success w100">

--- a/templates/coordinate/enrollments/index.hbs
+++ b/templates/coordinate/enrollments/index.hbs
@@ -6,7 +6,7 @@
         <h3 class="card-title">
         {{user.first_name}} {{user.last_name}} 
         <span class = "float-right">
-           {{#unless (and is_not_admin user.coordinating)}} 
+           {{#unless (and ../is_not_admin user.coordinating)}} 
                 <a class="btn btn-primary" href="/coordinate/semesters/enrollments/{{../semester_id}}/{{user.id}}/edit"> Edit User</a>
            {{/unless}}
         </span> 

--- a/templates/coordinate/enrollments/index.hbs
+++ b/templates/coordinate/enrollments/index.hbs
@@ -1,0 +1,21 @@
+<h1>{{title}} Enrollments</h1>
+
+{{#each data}}
+<div class="my-2 card text-dark">
+    <div class="card-header">
+        <h3 class="card-title">
+        {{user.first_name}} {{user.last_name}} 
+        <span class = "float-right">
+           {{#unless (and is_not_admin user.coordinating)}} 
+                <a class="btn btn-primary" href="/coordinate/semesters/enrollments/{{../semester_id}}/{{user.id}}/edit"> Edit User</a>
+           {{/unless}}
+        </span> 
+        </h3>
+
+    </div>
+</div>
+{{else}}
+<div class="justify-content-center">
+    Could not find any users matching these parameters.
+</div>
+{{/each}}

--- a/templates/coordinate/enrollments/index.hbs
+++ b/templates/coordinate/enrollments/index.hbs
@@ -1,5 +1,22 @@
 <h1>{{title}} Enrollments</h1>
 
+<form method="get" class="mb-2 form-inline" action="/coordinate/semesters/enrollments/{{semester_id}}/1">
+    <div class="input-group mr-2">
+        <div class="input-group-prepend">
+            <div class="input-group-text">
+                <i data-feather="search"></i>
+            </div>
+        </div>
+        <input type="search" name="search" class="form-control" placeholder="Search..." aria-label="Search"
+            {{#with query.search}} value="{{this}}" {{else}} {{! empty string -- no value }} {{/with}}
+        >
+    </div>
+    <button class="btn btn-primary" type="submit">View</button>
+</form>
+
+{{! Pagination buttons }}
+{{> pagination/pagination_bar pagination=pagination prefix=prefix preserved_query_string=preserved_query_string}}
+
 {{#each data}}
 <div class="my-2 card text-dark">
     <div class="card-header">
@@ -14,6 +31,7 @@
 
     </div>
 </div>
+
 {{else}}
 <div class="justify-content-center">
     Could not find any users matching these parameters.

--- a/templates/coordinate/index.hbs
+++ b/templates/coordinate/index.hbs
@@ -1,0 +1,51 @@
+<h1> Semester Records </h1>
+
+
+{{#if data.semesters}}
+<div class="table-responsive">
+    <table class="table table-striped table-light">
+        <thead>
+            <tr>
+                <th scope="col">Title
+                <th scope="col">Start
+                <th scope="col">End
+                <th scope="col">Project Pitches
+                <th scope="col">Meetings
+                <th scope="col">Enrollments
+            </tr>
+        </thead>
+        <tbody>
+           {{#each data.semesters as | semesters |}}
+                <tr>
+                    <th scope="row">{{title}}</th>
+                    <td>{{format_date start_date}}</td>
+                    <td>{{format_date end_date}}</td>
+                    {{#with project_pitches_aggregate.aggregate}}
+                        <td>
+                            <a href="coordinate/semesters/pitches/{{semesters.semester_id}}"/1 class="btn btn-info">
+                                {{count}}
+                            </a>
+                        </td>
+                    {{/with}}
+                    {{#with meetings_aggregate.aggregate}}
+                        <td>
+                            <a href="coordinate/semesters/meetings/{{semesters.semester_id}}"/1 class="btn btn-info">
+                                {{count}}
+                            </a>
+                        </td>
+                    {{/with}}
+                    {{#with enrollments_aggregate.aggregate}}
+                        <td>
+                            <a href="/coordinate/semesters/enrollments/{{semesters.semester_id}}/1" class="btn btn-info">
+                                {{count}}
+                            </a>
+                        </td>
+                    {{/with}}
+                </tr>
+            {{/each}}
+        </tbody>
+    </table>
+</div>
+{{else}}
+    No current semesters found.
+{{/if}}

--- a/templates/coordinate/index.hbs
+++ b/templates/coordinate/index.hbs
@@ -10,7 +10,6 @@
                 <th scope="col">Start
                 <th scope="col">End
                 <th scope="col">Project Pitches
-                <th scope="col">Meetings
                 <th scope="col">Enrollments
             </tr>
         </thead>
@@ -23,13 +22,6 @@
                     {{#with project_pitches_aggregate.aggregate}}
                         <td>
                             <a href="coordinate/semesters/pitches/{{semesters.semester_id}}"/1 class="btn btn-info">
-                                {{count}}
-                            </a>
-                        </td>
-                    {{/with}}
-                    {{#with meetings_aggregate.aggregate}}
-                        <td>
-                            <a href="coordinate/semesters/meetings/{{semesters.semester_id}}"/1 class="btn btn-info">
                                 {{count}}
                             </a>
                         </td>

--- a/templates/user/profile.hbs
+++ b/templates/user/profile.hbs
@@ -205,6 +205,11 @@
                         · <span class="badge badge-success">Project Lead</span>
                     {{/if}}
                 {{/if}}
+                <br>
+                {{! Grade Info }}
+                Mid-Year Grade: {{mid_year_grade}}  
+                <br>
+                Final Grade: {{final_grade}}
             </div>
         </div>
     {{else}}


### PR DESCRIPTION
Progress on #146,
Adds ability to edit enrollments in any current semester to the coordinator page.
Users also get relevant grade information on their profile page.
Things missing:
- Allow users to enroll in semesters
- Self service enrollment deletion
- JSON/CSV exportation
- Enrollment deletion

Also fixes some terribly ugly code I wrote earlier.