### PR TITLE
Enable dev mode for handlebars to reduce rebuilds

### DIFF
--- a/src/app_data.rs
+++ b/src/app_data.rs
@@ -21,6 +21,10 @@ impl AppData {
     fn new() -> Self {
         // Register handlebars templates
         let mut template_registry = Handlebars::new();
+        // If compiled in debug mode, do not cache templates
+        if cfg!(debug_assertions) {
+            template_registry.set_dev_mode(true);
+        }
         template_registry
             .register_templates_directory(".hbs", "templates")
             .map_err(|e| {


### PR DESCRIPTION
When in developer mode, handlebars reloads the template files every
request. This means you don't have to rebuild the rust code everytime
you modify the frontend.